### PR TITLE
Adds support for getting Slack token from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ users:read.email
 ```
 **Note**: User tokens act on behalf of the user who authorises them, so I would suggest you create this app and authorise it using a service account, otherwise the app will have access to your private channels and chats.
 
+#### Providing token
+Slack Watchman will first try to get the the Slack token from the environment variable `SLACK_WATCHMAN_TOKEN`, if this fails it will load the token from .conf file (see below).
 
 ### .conf file
 This API token needs to be stored in a file named `slack_watchman.conf` which is stored in your home directory. The file should take the following format:

--- a/watchman/__init__.py
+++ b/watchman/__init__.py
@@ -1,5 +1,4 @@
 import argparse
-import configparser
 import os
 import requests
 from colorama import init, deinit
@@ -17,12 +16,9 @@ def validate_conf(path):
         return True
 
 
-def validate_token(conf_path):
-    """Check the .conf file contains a token, then check whether that token is valid"""
-
-    config = configparser.ConfigParser()
-    config.read(conf_path)
-    token = config.get('auth', 'slack_token')
+def validate_token():
+    """Check that slack token is valid"""
+    token = audit.get_token()
 
     r = requests.get('https://slack.com/api/users.list',
                      params={'token': token,
@@ -94,13 +90,13 @@ def main():
             tf = d.ALL_TIME
 
         print(colored('''
-      _            _      _  __        ___  _____ ____ _   _ __  __    _    _   _ 
+      _            _      _  __        ___  _____ ____ _   _ __  __    _    _   _
   ___| | __ _  ___| | __ | | \ \      / / \|_   _/ ___| | | |  \/  |  / \  | \ | |
  / __| |/ _` |/ __| |/ / | |  \ \ /\ / / _ \ | || |   | |_| | |\/| | / _ \ |  \| |
  \__ \ | (_| | (__|   <  | |   \ V  V / ___ \| || |___|  _  | |  | |/ ___ \| |\  |
  |___/_|\__,_|\___|_|\_\ | |    \_/\_/_/   \_\_| \____|_| |_|_|  |_/_/   \_\_| \_|
-                         |_|                                                      
-                         
+                         |_|
+
                          ''', 'yellow'))
 
         conf_path = '{}/slack_watchman.conf'.format(os.path.expanduser('~'))

--- a/watchman/__init__.py
+++ b/watchman/__init__.py
@@ -12,7 +12,7 @@ from watchman import __about__ as a
 def validate_conf(path):
     """Check the file slack_watchman.conf exists"""
 
-    if os.path.exists(path):
+    if os.environ.get('SLACK_WATCHMAN_TOKEN') or os.path.exists(path):
         return True
 
 
@@ -102,8 +102,8 @@ def main():
         conf_path = '{}/slack_watchman.conf'.format(os.path.expanduser('~'))
 
         if not validate_conf(conf_path):
-            raise Exception(colored('slack_watchman.conf file not detected.'
-                            '\nEnsure a valid file is located in your home directory: {}', 'red')
+            raise Exception(colored('SLACK_WATCHMAN_TOKEN envvar or slack_watchman.conf file not detected.'
+                            '\nEnsure envvar is set or a valid file is located in your home directory: {}', 'red')
                             .format(os.path.expanduser('~')))
         else:
             validate_token(conf_path)

--- a/watchman/audit.py
+++ b/watchman/audit.py
@@ -10,12 +10,15 @@ import watchman.definitions as d
 
 
 def get_token():
-    """Get Slack API token from .conf file"""
+    """Get Slack API token from environment or .conf file"""
 
-    conf = configparser.ConfigParser()
-    path = '{}/slack_watchman.conf'.format(os.path.expanduser('~'))
-    conf.read(path)
-    token = conf.get('auth', 'slack_token')
+    try:
+        token = os.environ['SLACK_WATCHMAN_TOKEN']
+    except KeyError:
+        conf = configparser.ConfigParser()
+        path = '{}/slack_watchman.conf'.format(os.path.expanduser('~'))
+        conf.read(path)
+        token = conf.get('auth', 'slack_token')
 
     return token
 


### PR DESCRIPTION
Will try to get token from envvar `SLACK_WATCHMAN_TOKEN` and fall back to `.conf` file if envvar is not found.

Would close #5 