### PR TITLE
Develop

### DIFF
--- a/.github/workflows/dockerpublish.yml
+++ b/.github/workflows/dockerpublish.yml
@@ -2,7 +2,7 @@ name: ci
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, main ]
 
 jobs:
   build:

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -3,7 +3,7 @@ name: Poetry Publish
 
 on:
   push:
-    branches: [ main ]
+    branches: [ master, main ]
 
 jobs:
   deploy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [4.1.0] - 2024-09-12
+## [4.1.1] - 2024-09-14
 ### Added
 - Added enumeration of authentication options for the Workspace you authed to.
   - Shows which domains are authorised to create accounts on the workspace. If a historic domain that isn't registered anymore is still approved, you could access this workspace using an email from it.

--- a/poetry.lock
+++ b/poetry.lock
@@ -144,14 +144,17 @@ files = [
 
 [[package]]
 name = "idna"
-version = "3.8"
+version = "3.9"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "idna-3.8-py3-none-any.whl", hash = "sha256:050b4e5baadcd44d760cedbd2b8e639f2ff89bbc7a5730fcc662954303377aac"},
-    {file = "idna-3.8.tar.gz", hash = "sha256:d838c2c0ed6fced7693d5e8ab8e734d5f8fda53a039c0164afb0b82e771e3603"},
+    {file = "idna-3.9-py3-none-any.whl", hash = "sha256:69297d5da0cc9281c77efffb4e730254dd45943f45bbfb461de5991713989b1e"},
+    {file = "idna-3.9.tar.gz", hash = "sha256:e5c5dafde284f26e9e0f28f6ea2d6400abd5ca099864a67f576f3981c6476124"},
 ]
+
+[package.extras]
+all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
 
 [[package]]
 name = "pyyaml"
@@ -249,13 +252,13 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.2.2"
+version = "2.2.3"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "urllib3-2.2.2-py3-none-any.whl", hash = "sha256:a448b2f64d686155468037e1ace9f2d2199776e17f0a46610480d311f73e3472"},
-    {file = "urllib3-2.2.2.tar.gz", hash = "sha256:dd505485549a7a552833da5e6063639d0d177c04f23bc3864e41e5dc5f612168"},
+    {file = "urllib3-2.2.3-py3-none-any.whl", hash = "sha256:ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac"},
+    {file = "urllib3-2.2.3.tar.gz", hash = "sha256:e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9"},
 ]
 
 [package.extras]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "slack-watchman"
-version = "4.1.0"
+version = "4.1.1"
 description = "Monitoring and enumerating Slack for exposed secrets"
 authors = ["PaperMtn <papermtn@protonmail.com>"]
 license = "GPL-3.0"


### PR DESCRIPTION
## [4.1.1] - 2024-09-14
### Added
- Added enumeration of authentication options for the Workspace you authed to.
  - Shows which domains are authorised to create accounts on the workspace. If a historic domain that isn't registered anymore is still approved, you could access this workspace using an email from it.
  - Also shows which OAuth providers are authorised for the workspace.
- Added new 'unauthenticated probe' mode. This mode will attempt an unauthenticated probe on the workspace and return any available authentication information, as well as any other useful information such as whether the workspace is on a paid plan.
  - No authentication token is required in this mode, you can spray away to any workspace you like.

### Changed
- Signatures are now downloaded, processes and stored in memory instead of writing to disk. This saves having to store them in files, and solves the issues when using Slack Watchman with read-only filesystems (raised in [#51](https://github.com/PaperMtn/watchman-signatures/issues/51)) 
- Migrated to Poetry for dependency control and packaging