### PR TITLE
Feature/signature disable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [4.4.0] - 2024-11-12
+### Added
+- Ability to disable signatures by their ID in the `watchman.conf` config file.
+  - These signatures will not be used when running Slack Watchman
+  - Signature IDs for each signature can be found in the [Watchman Signatures repository](https://github.com/PaperMtn/watchman-signatures)
+
+### Fixed
+- Bug where variables were not being imported from watchman.conf config file
+
 ## [4.3.0] - 2024-10-27
 ### Changed
 - Timestamps are now in UTC across all logging for consistency

--- a/README.md
+++ b/README.md
@@ -78,6 +78,21 @@ slack-watchman --probe https://domain.slack.com
 ### Signatures
 Slack Watchman uses custom YAML signatures to detect matches in Slack. These signatures are pulled from the central [Watchman Signatures repository](https://github.com/PaperMtn/watchman-signatures). Slack Watchman automatically updates its signature base at runtime to ensure its using the latest signatures to detect secrets.
 
+#### Suppressing Signatures
+You can define signatures that you want to disable when running Slack Watchman by adding their IDs to the `disabled_signatures` section of the `watchman.conf` file. For example:
+
+```yaml
+slack_watchman:
+  token: ...
+  cookie: ...
+  url: ...
+  disabled_signatures:
+    - tokens_generic_bearer_tokens
+    - tokens_generic_access_tokens
+```
+
+You can find the ID of a signature in the individual YAML files in [Watchman Signatures repository](https://github.com/PaperMtn/watchman-signatures).
+
 ### Logging
 
 Slack Watchman gives the following logging options:
@@ -127,13 +142,16 @@ Slack Watchman will first try to get the Slack token (plus the cookie token and 
 
 If this fails it will try to load the token(s) from `.conf` file (see below).
 
-#### .conf file
+#### watchman.conf file
 Configuration options can be passed in a file named `watchman.conf` which must be stored in your home directory. The file should follow the YAML format, and should look like below:
 ```yaml
 slack_watchman:
   token: xoxp-xxxxxxxx
   cookie: xoxd-%2xxxxx
   url: https://xxxxx.slack.com
+  disabled_signatures:
+    - tokens_generic_bearer_tokens
+    - tokens_generic_access_tokens
 ```
 Slack Watchman will look for this file at runtime, and use the configuration options from here. If you are not using cookie auth, leave `cookie` and `url` blank.
 

--- a/docs/example.conf
+++ b/docs/example.conf
@@ -2,3 +2,6 @@ slack_watchman:
   token: xoxp-xxxxxxxx
   cookies: xoxd-%2xxxxx
   url: https://xxxxx.slack.com
+  disabled_signatures:
+    - tokens_generic_access_tokens
+    - tokens_generic_bearer_tokens

--- a/src/slack_watchman/__init__.py
+++ b/src/slack_watchman/__init__.py
@@ -14,77 +14,89 @@ from slack_watchman import (
     exceptions,
     watchman_processor
 )
+from slack_watchman.clients.slack_client import SlackClient
+from slack_watchman.loggers import (
+    StdoutLogger,
+    JSONLogger,
+    export_csv,
+    init_logger
+)
 from slack_watchman.models import (
     signature,
     user,
     workspace,
     post,
-    conversation
+    conversation,
+    auth_vars
 )
-from slack_watchman.loggers import StdoutLogger, JSONLogger, export_csv
-from slack_watchman.clients.slack_client import SlackClient
 
 OUTPUT_LOGGER: JSONLogger
 
 
-def validate_conf(path: str, cookie: bool) -> bool:
-    """ Check the file slack_watchman.conf exists
+def validate_conf(path: str, cookie_auth: bool) -> auth_vars.AuthVars:
+    """ Validates configuration and authentication settings for Slack Watchman from either
+        a config file or environment variables.
+        Authentication tokens from Environment Variables take precedence over those
+        from the config file.
+        Additional configuration settings, such as suppressed signatures, are loaded from the config file.
 
     Args:
         path: Path for the .config file
-        cookie: Whether session:cookie auth is being used
+        cookie_auth: Whether session:cookie auth is being used
     Returns:
-        True if the required config settings are present, False if not
+        AuthVars object containing the authentication details
+    Raises:
+        MissingEnvVarError: If a required environment variable is not set
+        MissingCookieEnvVarError: If required variables for cookie auth aren't set
+        MisconfiguredConfFileError: If the config file is not valid
     """
 
-    if not cookie:
-        if not os.environ.get('SLACK_WATCHMAN_TOKEN'):
-            if os.path.exists(f'{os.path.expanduser("~")}/slack_watchman.conf'):
-                OUTPUT_LOGGER.log('WARNING', 'Legacy slack_watchman.conf file detected. Renaming to watchman.conf')
-                os.rename(rf'{os.path.expanduser("~")}/slack_watchman.conf',
-                          rf'{os.path.expanduser("~")}/watchman.conf')
-                try:
-                    with open(path) as yaml_file:
-                        return yaml.safe_load(yaml_file)['slack_watchman']
-                except:
-                    raise exceptions.MisconfiguredConfFileError
-            elif os.path.exists(path):
-                try:
-                    with open(path) as yaml_file:
-                        return yaml.safe_load(yaml_file)['slack_watchman']
-                except:
-                    raise exceptions.MisconfiguredConfFileError
-            else:
-                try:
-                    os.environ['SLACK_WATCHMAN_TOKEN']
-                except:
-                    raise exceptions.MissingEnvVarError('SLACK_WATCHMAN_TOKEN')
-    else:
-        if os.path.exists(f'{os.path.expanduser("~")}/slack_watchman.conf'):
-            OUTPUT_LOGGER.log('WARNING', 'Legacy slack_watchman.conf file detected. Renaming to watchman.conf')
-            os.rename(rf'{os.path.expanduser("~")}/slack_watchman.conf',
-                      rf'{os.path.expanduser("~")}/watchman.conf')
-            try:
-                with open(path) as yaml_file:
-                    return yaml.safe_load(yaml_file)['slack_watchman']
-            except:
-                raise exceptions.MisconfiguredConfFileError
-        elif os.path.exists(path):
-            try:
-                with open(path) as yaml_file:
-                    return yaml.safe_load(yaml_file)['slack_watchman']
-            except:
-                raise exceptions.MisconfiguredConfFileError
-        else:
-            try:
-                os.environ['SLACK_WATCHMAN_COOKIE']
-            except:
-                raise exceptions.MissingEnvVarError('SLACK_WATCHMAN_COOKIE')
+    # Check for legacy config file and rename if necessary
+    legacy_path = f'{os.path.expanduser("~")}/slack_watchman.conf'
+    if os.path.exists(legacy_path):
+        OUTPUT_LOGGER.log('WARNING', 'Legacy slack_watchman.conf file detected. Renaming to watchman.conf')
+        os.rename(legacy_path, path)
 
-            try:
-                os.environ['SLACK_WATCHMAN_URL']
-            except:
-                raise exceptions.MissingEnvVarError('SLACK_WATCHMAN_URL')
+    auth_info = auth_vars.AuthVars(
+        token=None,
+        cookie=None,
+        url=None,
+        disabled_signatures=None,
+        cookie_auth=cookie_auth
+    )
+
+    # Check if config file exists
+    if os.path.exists(path):
+        try:
+            with open(path) as yaml_file:
+                conf_details = yaml.safe_load(yaml_file)['slack_watchman']
+                auth_info.disabled_signatures = conf_details.get('disabled_signatures')
+        except Exception:
+            raise exceptions.MisconfiguredConfFileError
+
+    if not cookie_auth:
+        # First try SLACK_WATCHMAN_TOKEN env var
+        try:
+            auth_info.token = os.environ['SLACK_WATCHMAN_TOKEN']
+        except KeyError:
+            # Failing that, try to get SLACK_WATCHMAN_TOKEN from config
+            if conf_details.get('token'):
+                auth_info.token = conf_details.get('token')
+            else:
+                raise exceptions.MissingEnvVarError('SLACK_WATCHMAN_TOKEN')
+    else:
+        # First try SLACK_WATCHMAN_COOKIE and SLACK_WATCHMAN_URL env vars
+        try:
+            auth_info.cookie = os.environ['SLACK_WATCHMAN_COOKIE']
+            auth_info.url = os.environ['SLACK_WATCHMAN_URL']
+        except KeyError as e:
+            # Failing that, try to get SLACK_WATCHMAN_COOKIE and SLACK_WATCHMAN_URL from config
+            if conf_details.get('cookie') and conf_details.get('url'):
+                auth_info.cookie = conf_details.get('cookie')
+                auth_info.url = conf_details.get('url')
+            else:
+                raise exceptions.MissingCookieEnvVarError(e.args[0])
+    return auth_info
 
 
 def search(slack_connection: SlackClient,
@@ -177,22 +189,6 @@ def unauthenticated_probe(workspace_domain: str,
         sys.exit(1)
 
 
-def init_logger(logging_type: str, debug: bool) -> JSONLogger | StdoutLogger:
-    """ Create a logger object. Defaults to stdout if no option is given
-
-    Args:
-        logging_type: Type of logging to use
-        debug: Whether to use debug level logging or not
-    Returns:
-        Logger object
-    """
-
-    if not logging_type or logging_type == 'stdout':
-        return StdoutLogger(debug=debug)
-    else:
-        return JSONLogger(debug=debug)
-
-
 def main():
     global OUTPUT_LOGGER
     try:
@@ -270,8 +266,8 @@ def main():
             unauthenticated_probe(probe_domain, project_metadata)
 
         conf_path = f'{os.path.expanduser("~")}/watchman.conf'
-        validate_conf(conf_path, cookie)
-        slack_con = watchman_processor.initiate_slack_connection(cookie)
+        auth_info = validate_conf(conf_path, cookie)
+        slack_con = watchman_processor.initiate_slack_connection(auth_info)
 
         auth_data = slack_con.get_auth_test()
         calling_user = user.create_from_dict(

--- a/src/slack_watchman/exceptions.py
+++ b/src/slack_watchman/exceptions.py
@@ -8,6 +8,17 @@ class MissingEnvVarError(Exception):
         super().__init__(self.message)
 
 
+class MissingCookieEnvVarError(Exception):
+    """ Exception raised when a cookie environment variable is missing.
+    """
+
+    def __init__(self, env_var):
+        self.env_var = env_var
+        self.message = (f'Cookie authentication has been selected, but missing'
+                        f'required environment variable: {self.env_var}')
+        super().__init__(self.message)
+
+
 class MisconfiguredConfFileError(Exception):
     """ Exception raised when the config file watchman.conf is missing.
     """

--- a/src/slack_watchman/loggers.py
+++ b/src/slack_watchman/loggers.py
@@ -345,3 +345,19 @@ def export_csv(csv_name: str, export_data: List[IsDataclass]) -> None:
         f.close()
     except Exception as e:
         print(e)
+
+
+def init_logger(logging_type: str, debug: bool) -> JSONLogger | StdoutLogger:
+    """ Create a logger object. Defaults to stdout if no option is given
+
+    Args:
+        logging_type: Type of logging to use
+        debug: Whether to use debug level logging or not
+    Returns:
+        Logger object
+    """
+
+    if not logging_type or logging_type == 'stdout':
+        return StdoutLogger(debug=debug)
+    else:
+        return JSONLogger(debug=debug)

--- a/src/slack_watchman/models/auth_vars.py
+++ b/src/slack_watchman/models/auth_vars.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+from typing import Optional, List
+
+
+@dataclass
+class AuthVars:
+    """ Class for managing authentication and configuration variables """
+    token: Optional[str] | None
+    cookie: Optional[str] | None
+    url: Optional[str] | None
+    disabled_signatures: Optional[List[str]] | None
+    cookie_auth: bool

--- a/src/slack_watchman/models/signature.py
+++ b/src/slack_watchman/models/signature.py
@@ -22,6 +22,7 @@ class Signature:
     They also contain regex patterns to validate data that is found"""
 
     name: str
+    id: str
     status: str
     author: str
     date: str | datetime.date | datetime.datetime
@@ -39,6 +40,8 @@ class Signature:
     def __post_init__(self):
         if self.name and not isinstance(self.name, str):
             raise TypeError(f'Expected `name` to be of type str, received {type(self.name).__name__}')
+        if self.id and not isinstance(self.id, str):
+            raise TypeError(f'Expected `id` to be of type str, received {type(self.id).__name__}')
         if self.status and not isinstance(self.status, str):
             raise TypeError(f'Expected `status` to be of type str, received {type(self.status).__name__}')
         if self.author and not isinstance(self.author, str):
@@ -82,6 +85,7 @@ def create_from_dict(signature_dict: Dict[str, Any]) -> Signature:
 
     return Signature(
         name=signature_dict.get('name'),
+        id=(signature_dict.get('id')),
         status=signature_dict.get('status'),
         author=signature_dict.get('author'),
         date=signature_dict.get('date'),

--- a/tests/unit/models/fixtures.py
+++ b/tests/unit/models/fixtures.py
@@ -1,0 +1,47 @@
+import pytest
+
+from slack_watchman.models import (
+    signature
+)
+
+
+class SlackMockData:
+    SIGNATURE_DICT = {
+        'name': 'Akamai API Access Tokens',
+        'id': 'akamai_api_access_tokens',
+        'status': 'enabled',
+        'author': 'PaperMtn',
+        'date': '2023-12-22',
+        'description': 'Detects exposed Akamai API Access tokens',
+        'severity': '90',
+        'notes': None,
+        'references': None,
+        'watchman_apps': {
+            'slack_std': {
+                'category': 'secrets',
+                'scope': [
+                    'messages'
+                ],
+                'file_types': None,
+                'search_strings': [
+                    'akab-'
+                ]
+            }
+        },
+        'test_cases': {
+            'match_cases': [
+                'client_token: akab-rWdcwwASNbe9fcGk-00qwecOueticOXxA'
+            ],
+            'fail_cases': [
+                'host: akab-fakehost.akamaiapis.net'
+            ]
+        },
+        'patterns': [
+            'akab-[0-9a-zA-Z]{16}-[0-9a-zA-Z]{16}'
+        ]
+    }
+
+
+@pytest.fixture
+def mock_signature():
+    return signature.create_from_dict(SlackMockData.SIGNATURE_DICT)

--- a/tests/unit/models/fixtures.py
+++ b/tests/unit/models/fixtures.py
@@ -1,7 +1,8 @@
 import pytest
 
 from slack_watchman.models import (
-    signature
+    signature,
+    auth_vars
 )
 
 
@@ -41,7 +42,20 @@ class SlackMockData:
         ]
     }
 
+    AUTH_VARS_DICT = {
+        'token': 'xoxp-1234',
+        'cookie': 'xoxd-1234',
+        'url': 'https://slack.com',
+        'disabled_signatures': ['tokens_generic_access_tokens', 'tokens_generic_bearer_tokens'],
+        'cookie_auth': True
+    }
+
 
 @pytest.fixture
 def mock_signature():
     return signature.create_from_dict(SlackMockData.SIGNATURE_DICT)
+
+
+@pytest.fixture
+def mock_auth_vars():
+    return auth_vars.AuthVars(**SlackMockData.AUTH_VARS_DICT)

--- a/tests/unit/models/test_unit_auth_vars.py
+++ b/tests/unit/models/test_unit_auth_vars.py
@@ -1,0 +1,14 @@
+from fixtures import SlackMockData, mock_auth_vars
+from slack_watchman.models import auth_vars
+
+
+def test_auth_vars_initialisation(mock_auth_vars):
+    # Test that the auth_vars object is initialised
+    assert isinstance(mock_auth_vars, auth_vars.AuthVars)
+
+    # Test that the auth_vars object has the correct attributes
+    assert mock_auth_vars.token == SlackMockData.AUTH_VARS_DICT.get('token')
+    assert mock_auth_vars.cookie == SlackMockData.AUTH_VARS_DICT.get('cookie')
+    assert mock_auth_vars.url == SlackMockData.AUTH_VARS_DICT.get('url')
+    assert mock_auth_vars.disabled_signatures == SlackMockData.AUTH_VARS_DICT.get('disabled_signatures')
+    assert mock_auth_vars.cookie_auth == SlackMockData.AUTH_VARS_DICT.get('cookie_auth')

--- a/tests/unit/models/test_unit_signature.py
+++ b/tests/unit/models/test_unit_signature.py
@@ -1,71 +1,34 @@
 import pytest
 from slack_watchman.models import signature
-
-SIGNATURE_DICT = {
-    'name': 'Akamai API Access Tokens',
-    'status': 'enabled',
-    'author': 'PaperMtn',
-    'date': '2023-12-22',
-    'description': 'Detects exposed Akamai API Access tokens',
-    'severity': '90',
-    'notes': None,
-    'references': None,
-    'watchman_apps': {
-        'slack_std': {
-            'category': 'secrets',
-            'scope': [
-                'messages'
-            ],
-            'file_types': None,
-            'search_strings': [
-                'akab-'
-            ]
-        }
-    },
-    'test_cases': {
-        'match_cases': [
-            'client_token: akab-rWdcwwASNbe9fcGk-00qwecOueticOXxA'
-        ],
-        'fail_cases': [
-            'host: akab-fakehost.akamaiapis.net'
-        ]
-    },
-    'patterns': [
-        'akab-[0-9a-zA-Z]{16}-[0-9a-zA-Z]{16}'
-    ]
-}
+from fixtures import SlackMockData, mock_signature
 
 
-@pytest.fixture
-def example_signature():
-    return signature.create_from_dict(SIGNATURE_DICT)
-
-
-def test_signature_initialisation(example_signature):
+def test_signature_initialisation(mock_signature):
     # Test that the signature object is initialised
-    assert isinstance(example_signature, signature.Signature)
+    assert isinstance(mock_signature, signature.Signature)
 
     # Test that the signature object has the correct attributes
-    assert example_signature.name == SIGNATURE_DICT.get('name')
-    assert example_signature.status == SIGNATURE_DICT.get('status')
-    assert example_signature.author == SIGNATURE_DICT.get('author')
-    assert example_signature.date == SIGNATURE_DICT.get('date')
-    assert example_signature.description == SIGNATURE_DICT.get('description')
-    assert example_signature.severity == SIGNATURE_DICT.get('severity')
-    assert example_signature.watchman_apps == SIGNATURE_DICT.get('watchman_apps')
-    assert example_signature.category == SIGNATURE_DICT.get('watchman_apps').get('slack_std').get('category')
+    assert mock_signature.name == SlackMockData.SIGNATURE_DICT.get('name')
+    assert mock_signature.id == SlackMockData.SIGNATURE_DICT.get('id')
+    assert mock_signature.status == SlackMockData.SIGNATURE_DICT.get('status')
+    assert mock_signature.author == SlackMockData.SIGNATURE_DICT.get('author')
+    assert mock_signature.date == SlackMockData.SIGNATURE_DICT.get('date')
+    assert mock_signature.description == SlackMockData.SIGNATURE_DICT.get('description')
+    assert mock_signature.severity == SlackMockData.SIGNATURE_DICT.get('severity')
+    assert mock_signature.watchman_apps == SlackMockData.SIGNATURE_DICT.get('watchman_apps')
+    assert mock_signature.category == SlackMockData.SIGNATURE_DICT.get('watchman_apps').get('slack_std').get('category')
 
 
 def test_field_type():
     # Test that correct error is raised when name is not a string
-    signature_dict = SIGNATURE_DICT
+    signature_dict = SlackMockData.SIGNATURE_DICT
     signature_dict['name'] = 123
     with pytest.raises(TypeError):
         test_signature = signature.create_from_dict(signature_dict)
 
 
 def test_missing_field():
-    temp_signature_dict = SIGNATURE_DICT.copy()
+    temp_signature_dict = SlackMockData.SIGNATURE_DICT.copy()
     del temp_signature_dict['name']
     test_signature = signature.create_from_dict(temp_signature_dict)
     assert test_signature.name is None


### PR DESCRIPTION
### Added
- Ability to disable signatures by their ID in the `watchman.conf` config file.
  - These signatures will not be used when running Slack Watchman
  - Signature IDs for each signature can be found in the [Watchman Signatures repository](https://github.com/PaperMtn/watchman-signatures)