### PR TITLE
Hotfix/suppress crash fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [4.4.1] - 2024-12-18
+### Fixed
+- Fixed a bug where an exception was raised when no suppressed signatures were passed
+  - Fixes [Issue #66](https://github.com/PaperMtn/slack-watchman/issues/66)
+
 ## [4.4.0] - 2024-11-20
 ### Added
 - Ability to disable signatures by their ID in the `watchman.conf` config file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## [4.4.1] - 2024-12-18
 ### Fixed
-- Fixed a bug where an exception was raised when no suppressed signatures were passed
-  - Fixes [Issue #66](https://github.com/PaperMtn/slack-watchman/issues/66)
+- Fixed a bug where an exception was raised when no suppressed signatures were passed. Fixes [#66](https://github.com/PaperMtn/slack-watchman/issues/66)
+- Fixed error when creating a Workspace object using the response from the Slack API. Validation was expecting a `bool`, but in some instances, a string was being returned. Fixes [#68](https://github.com/PaperMtn/slack-watchman/issues/68)
+- Fixed bug where the incorrect error message was being passed when environment variables were not set. Fixes [#67](https://github.com/PaperMtn/slack-watchman/issues/67)
 
 ## [4.4.0] - 2024-11-20
 ### Added

--- a/src/slack_watchman/__init__.py
+++ b/src/slack_watchman/__init__.py
@@ -109,8 +109,10 @@ def suppress_disabled_signatures(signatures: List[signature.Signature],
     Returns:
         List of signatures with disabled signatures removed
     """
-
-    return [sig for sig in signatures if sig.id not in disabled_signatures]
+    try:
+        return [sig for sig in signatures if sig.id not in disabled_signatures]
+    except TypeError:
+        return signatures
 
 
 def search(slack_connection: SlackClient,

--- a/src/slack_watchman/__init__.py
+++ b/src/slack_watchman/__init__.py
@@ -35,11 +35,8 @@ OUTPUT_LOGGER: JSONLogger
 
 
 def validate_conf(cookie_auth: bool) -> auth_vars.AuthVars:
-    """ Validates configuration and authentication settings for Slack Watchman from either
-        a config file or environment variables.
-        Authentication tokens from Environment Variables take precedence over those
-        from the config file.
-        Additional configuration settings, such as suppressed signatures, are loaded from the config file.
+    """ Validates configuration and authentication settings for Slack Watchman.
+    Authentication tokens from environment variables take precedence over config file values.
 
     Args:
         cookie_auth: Whether session:cookie auth is being used
@@ -50,12 +47,16 @@ def validate_conf(cookie_auth: bool) -> auth_vars.AuthVars:
         MissingCookieEnvVarError: If required variables for cookie auth aren't set
         MisconfiguredConfFileError: If the config file is not valid
     """
+    home_dir = os.path.expanduser("~")
+    path = f"{home_dir}/watchman.conf"
+    legacy_path = f"{home_dir}/slack_watchman.conf"
 
-    # Check for legacy config file and rename if necessary
-    path = f'{os.path.expanduser("~")}/watchman.conf'
-    legacy_path = f'{os.path.expanduser("~")}/slack_watchman.conf'
+    # Handle legacy config file renaming
     if os.path.exists(legacy_path):
-        OUTPUT_LOGGER.log('WARNING', 'Legacy slack_watchman.conf file detected. Renaming to watchman.conf')
+        OUTPUT_LOGGER.log(
+            "WARNING",
+            "Legacy slack_watchman.conf file detected. Renaming to watchman.conf"
+        )
         os.rename(legacy_path, path)
 
     auth_info = auth_vars.AuthVars(
@@ -66,37 +67,32 @@ def validate_conf(cookie_auth: bool) -> auth_vars.AuthVars:
         cookie_auth=cookie_auth
     )
 
-    # Check if config file exists
+    conf_details = {}
     if os.path.exists(path):
         try:
-            with open(path, encoding='utf-8') as yaml_file:
-                conf_details = yaml.safe_load(yaml_file)['slack_watchman']
-                auth_info.disabled_signatures = conf_details.get('disabled_signatures')
+            with open(path, encoding="utf-8") as yaml_file:
+                conf_details = yaml.safe_load(yaml_file).get("slack_watchman", {})
+                auth_info.disabled_signatures = conf_details.get("disabled_signatures")
         except Exception as e:
             raise exceptions.MisconfiguredConfFileError from e
 
+    def get_env_or_conf(key: str, conf_key: str = None) -> str:
+        """ Retrieve value from environment or config."""
+        return os.environ.get(key) or conf_details.get(conf_key or key.lower())
+
     if not cookie_auth:
-        # First try SLACK_WATCHMAN_TOKEN env var
-        try:
-            auth_info.token = os.environ['SLACK_WATCHMAN_TOKEN']
-        except KeyError as e:
-            # Failing that, try to get SLACK_WATCHMAN_TOKEN from config
-            if conf_details.get('token'):
-                auth_info.token = conf_details.get('token')
-            else:
-                raise exceptions.MissingEnvVarError('SLACK_WATCHMAN_TOKEN') from e
+        auth_info.token = get_env_or_conf("SLACK_WATCHMAN_TOKEN", 'token')
+        if not auth_info.token:
+            raise exceptions.MissingEnvVarError("SLACK_WATCHMAN_TOKEN")
     else:
-        # First try SLACK_WATCHMAN_COOKIE and SLACK_WATCHMAN_URL env vars
-        try:
-            auth_info.cookie = os.environ['SLACK_WATCHMAN_COOKIE']
-            auth_info.url = os.environ['SLACK_WATCHMAN_URL']
-        except KeyError as e:
-            # Failing that, try to get SLACK_WATCHMAN_COOKIE and SLACK_WATCHMAN_URL from config
-            if conf_details.get('cookie') and conf_details.get('url'):
-                auth_info.cookie = conf_details.get('cookie')
-                auth_info.url = conf_details.get('url')
-            else:
-                raise exceptions.MissingCookieEnvVarError(e.args[0])
+        auth_info.cookie = get_env_or_conf("SLACK_WATCHMAN_COOKIE", "cookie")
+        auth_info.url = get_env_or_conf("SLACK_WATCHMAN_URL", "url")
+
+        if not auth_info.cookie:
+            raise exceptions.MissingCookieEnvVarError("SLACK_WATCHMAN_COOKIE")
+        if not auth_info.url:
+            raise exceptions.MissingCookieEnvVarError("SLACK_WATCHMAN_URL")
+
     return auth_info
 
 

--- a/src/slack_watchman/exceptions.py
+++ b/src/slack_watchman/exceptions.py
@@ -14,8 +14,19 @@ class MissingCookieEnvVarError(Exception):
 
     def __init__(self, env_var):
         self.env_var = env_var
-        self.message = (f'Cookie authentication has been selected, but missing'
+        self.message = (f'Cookie authentication has been selected, but missing '
                         f'required environment variable: {self.env_var}')
+        super().__init__(self.message)
+
+
+class MissingCookieAuthError(Exception):
+    """ Exception raised when a cookie auth is selected, but no cookie is set.
+    """
+
+    def __init__(self):
+        self.message = (f'Cookie authentication has been selected, but missing no authentication data '
+                        f'has been provided. Please set the environment variables SLACK_WATCHMAN_COOKIE and '
+                        f'SLACK_WATCHMAN_URL')
         super().__init__(self.message)
 
 

--- a/src/slack_watchman/exceptions.py
+++ b/src/slack_watchman/exceptions.py
@@ -24,9 +24,9 @@ class MissingCookieAuthError(Exception):
     """
 
     def __init__(self):
-        self.message = (f'Cookie authentication has been selected, but missing no authentication data '
-                        f'has been provided. Please set the environment variables SLACK_WATCHMAN_COOKIE and '
-                        f'SLACK_WATCHMAN_URL')
+        self.message = ('Cookie authentication has been selected, but missing no authentication data '
+                        'has been provided. Please set the environment variables SLACK_WATCHMAN_COOKIE and '
+                        'SLACK_WATCHMAN_URL')
         super().__init__(self.message)
 
 

--- a/src/slack_watchman/models/workspace.py
+++ b/src/slack_watchman/models/workspace.py
@@ -26,8 +26,8 @@ class Workspace:
             'domain': str,
             'url': str,
             'email_domain': str,
-            'is_verified': (bool, type(None)),
-            'discoverable': (bool, type(None)),
+            'is_verified': (bool, str, type(None)),
+            'discoverable': (bool, str, type(None)),
             'enterprise_id': (str, type(None)),
             'enterprise_domain': (str, type(None)),
             'enterprise_name': (str, type(None)),
@@ -40,6 +40,7 @@ class Workspace:
                     f'Expected `{field_name}` to be of type {expected_type}, '
                     f'received {type(value).__name__}'
                 )
+
 
 def create_from_dict(workspace_dict: Dict) -> Workspace:
     """ Return a Workspace object based off an input dictionary

--- a/tests/unit/test_unit_exceptions.py
+++ b/tests/unit/test_unit_exceptions.py
@@ -9,6 +9,7 @@ from slack_watchman.exceptions import (
     SlackScopeError,
     SlackAPIError,
     SlackAPIRateLimit,
+    MissingCookieAuthError
 )
 
 
@@ -26,7 +27,7 @@ def test_missing_cookie_env_var_error():
     exc = MissingCookieEnvVarError(env_var)
     assert exc.env_var == env_var
     assert exc.message == (
-        f'Cookie authentication has been selected, but missing'
+        f'Cookie authentication has been selected, but missing '
         f'required environment variable: {env_var}'
     )
     with pytest.raises(MissingCookieEnvVarError, match=f'Cookie authentication has been selected, but missing'):
@@ -82,4 +83,15 @@ def test_slack_api_rate_limit():
     exc = SlackAPIRateLimit()
     assert exc.message == 'Slack API rate limit reached - cooling off'
     with pytest.raises(SlackAPIRateLimit, match='Slack API rate limit reached - cooling off'):
+        raise exc
+
+
+def test_missing_cookie_auth_error():
+    exc = MissingCookieAuthError()
+    assert exc.message == (
+        'Cookie authentication has been selected, but missing no authentication data '
+        'has been provided. Please set the environment variables SLACK_WATCHMAN_COOKIE and '
+        'SLACK_WATCHMAN_URL'
+    )
+    with pytest.raises(MissingCookieAuthError, match='Cookie authentication has been selected, but missing'):
         raise exc


### PR DESCRIPTION
### Fixed
- Fixed a bug where an exception was raised when no suppressed signatures were passed. Fixes [#66](https://github.com/PaperMtn/slack-watchman/issues/66)
- Fixed error when creating a Workspace object using the response from the Slack API. Validation was expecting a `bool`, but in some instances, a string was being returned. Fixes [#68](https://github.com/PaperMtn/slack-watchman/issues/68)
- Fixed bug where the incorrect error message was being passed when environment variables were not set. Fixes [#67](https://github.com/PaperMtn/slack-watchman/issues/67)