### PR TITLE
Release/4.4.4

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: PaperMtn
+ko_fi: papermtn

--- a/.github/workflows/docker_build_test.yml
+++ b/.github/workflows/docker_build_test.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           load: true
           tags: ${{ env.TEST_TAG }}

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       -
         name: Login to Docker Hub
         uses: docker/login-action@v2
@@ -19,7 +19,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
       -
         name: Build and push
         uses: docker/build-push-action@v4

--- a/.github/workflows/github_release.yml
+++ b/.github/workflows/github_release.yml
@@ -12,9 +12,9 @@ jobs:
         python-version: [ '3.12' ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -33,7 +33,7 @@ jobs:
           python3 -m pip install dist/*.whl
       - name: Extract release notes
         id: extract-release-notes
-        uses: ffurrer2/extract-release-notes@v1
+        uses: ffurrer2/extract-release-notes@v3
         with:
           changelog_file: CHANGELOG.md
       - name: Retrieve version

--- a/.github/workflows/github_release_notes_test.yml
+++ b/.github/workflows/github_release_notes_test.yml
@@ -1,4 +1,4 @@
-name: Create GitHub Release
+name: Test GitHub Release Tag and Notes Extraction
 
 on:
   push:
@@ -17,6 +17,14 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          pip install flake8 poetry
+          poetry install
+      - name: Install
+        run: |
+          poetry build
+          python3 -m pip install dist/*.whl
       - name: Extract release notes
         id: extract-release-notes
         uses: ffurrer2/extract-release-notes@v1

--- a/.github/workflows/github_release_notes_test.yml
+++ b/.github/workflows/github_release_notes_test.yml
@@ -12,9 +12,9 @@ jobs:
         python-version: [ '3.12' ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -27,7 +27,7 @@ jobs:
           python3 -m pip install dist/*.whl
       - name: Extract release notes
         id: extract-release-notes
-        uses: ffurrer2/extract-release-notes@v1
+        uses: ffurrer2/extract-release-notes@v3
         with:
           changelog_file: CHANGELOG.md
       - name: Retrieve version

--- a/.github/workflows/github_release_notes_test.yml
+++ b/.github/workflows/github_release_notes_test.yml
@@ -1,0 +1,33 @@
+name: Create GitHub Release
+
+on:
+  push:
+    branches: [ release/**, hotfix/** ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ '3.12' ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Extract release notes
+        id: extract-release-notes
+        uses: ffurrer2/extract-release-notes@v1
+        with:
+          changelog_file: CHANGELOG.md
+      - name: Retrieve version
+        run: |
+          echo "TAG_NAME=$(slack-watchman -v | awk '{match($0, /[0-9]+\.[0-9]+\.[0-9]+/); print substr($0, RSTART, RLENGTH)}')" >> $GITHUB_OUTPUT
+        id: version
+      - name: Test tag and release notes
+        # This step prints the tag and release notes to the console for verification before creating the release.
+        run: |
+          echo "Tag: ${{ steps.version.outputs.TAG_NAME }}"
+          echo "Release Notes: ${{ steps.extract-release-notes.outputs.release_notes }}"

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -15,9 +15,9 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/python_publish.yml
+++ b/.github/workflows/python_publish.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v6
       with:
         python-version: '3.12'
     - name: Install dependencies

--- a/.github/workflows/python_run_integration_tests.yml
+++ b/.github/workflows/python_run_integration_tests.yml
@@ -21,9 +21,9 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/python_run_tests.yml
+++ b/.github/workflows/python_run_tests.yml
@@ -11,9 +11,9 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [4.4.4] - 2026-03-29
+### Added
+- Added GitHub Action to test release notes and version tag for GitHub releases
+
 ### Changed
 - Dependabot updates
   - `requests` updated to `2.33.0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.4.4] - 2026-03-29
+### Changed
+- Dependabot updates
+  - `requests` updated to `2.33.0`
+
+### Fixed
+- Fixed broken link to Slack Cookie Authentication blog post in README (raised in [#82] by @emilstahl)
+
 ## [4.4.3] - 2025-12-06
 ### Changed
 - Dependabot updates
   - `urllib3` updated to `2.6.0`
-
-### Fixed
-- Fixed broken link to Slack Cookie Authentication blog post in README (raised in [#82] by @emilstahl)
 
 ## [4.4.2] - 2025-07-05
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Dependabot updates
   - `requests` updated to `2.33.0`
+- Update GitHub Actions that use Node.js 20 to the latest versions to support Node.js 24
 
 ### Fixed
 - Fixed broken link to Slack Cookie Authentication blog post in README (raised in [#82] by @emilstahl)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "slack-watchman"
-version = "4.4.3"
+version = "4.4.4"
 description = "Monitoring and enumerating Slack for exposed secrets"
 authors = ["PaperMtn <me@papermtn.co.uk>"]
 license = "GPL-3.0"


### PR DESCRIPTION
## [4.4.4] - 2026-03-29
### Added
- Added GitHub Action to test release notes and version tag for GitHub releases

### Changed
- Dependabot updates
  - `requests` updated to `2.33.0`
- Update GitHub Actions that use Node.js 20 to the latest versions to support Node.js 24

### Fixed
- Fixed broken link to Slack Cookie Authentication blog post in README (raised in [#82] by @emilstahl)