### PR TITLE
Release/4.4.5

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,5 @@ updates:
     allow:
       - dependency-type: "direct"
     insecure-external-code-execution: "deny"
-    ignore:
-      - dependency-name: "*"
+    security-updates-only: true
     versioning-strategy: increase

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.4.5] - 2026-xx-xx
+## [4.4.5] - 2026-04-27
 ### Changed
 - Updated dependabot.yml to created PRs against `develop` branch instead of `maaster`
 - Dependabot updates:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.4.5] - 2026-xx-xx
+### Changed
+- Updated dependabot.yml to created PRs against `develop` branch instead of `maaster`
+- Dependabot updates:
+  - `requests` updated to `2.33.1`
+  - `pygments` updated to `2.20.0`
+  - `pytest` updated to `9.0.3`
+
 ## [4.4.4] - 2026-03-29
 ### Added
 - Added GitHub Action to test release notes and version tag for GitHub releases

--- a/poetry.lock
+++ b/poetry.lock
@@ -429,14 +429,14 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 description = "Pygments is a syntax highlighting package written in Python."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b"},
-    {file = "pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887"},
+    {file = "pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"},
+    {file = "pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f"},
 ]
 
 [package.extras]
@@ -474,14 +474,14 @@ testutils = ["gitpython (>3)"]
 
 [[package]]
 name = "pytest"
-version = "9.0.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b"},
-    {file = "pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
@@ -581,14 +581,14 @@ files = [
 
 [[package]]
 name = "requests"
-version = "2.33.0"
+version = "2.33.1"
 description = "Python HTTP for Humans."
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "requests-2.33.0-py3-none-any.whl", hash = "sha256:3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b"},
-    {file = "requests-2.33.0.tar.gz", hash = "sha256:c7ebc5e8b0f21837386ad0e1c8fe8b829fa5f544d8df3b2253bff14ef29d7652"},
+    {file = "requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a"},
+    {file = "requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517"},
 ]
 
 [package.dependencies]
@@ -599,7 +599,6 @@ urllib3 = ">=1.26,<3"
 
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
-test = ["PySocks (>=1.5.6,!=1.5.7)", "pytest (>=3)", "pytest-cov", "pytest-httpbin (==2.1.0)", "pytest-mock", "pytest-xdist"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<8)"]
 
 [[package]]
@@ -703,4 +702,4 @@ zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10"
-content-hash = "01a0d80e9d0226c03616023c0b79c8f3ce5d0eb0982e988f38afe14c54918fd4"
+content-hash = "74c396855ca1ed7e22b3c8feb7703fa608615b1579b6da260f874fa4285e62f2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,11 +20,11 @@ classifiers = [
 python = ">=3.10"
 colorama = "^0.4.6"
 pyyaml = "^6.0.3"
-requests = "^2.33.0"
+requests = "^2.33.1"
 beautifulsoup4 = "^4.14.3"
 
 [tool.poetry.group.dev.dependencies]
-pytest = "^9.0.2"
+pytest = "^9.0.3"
 coverage = "^7.13.5"
 pylint = "^4.0.5"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "slack-watchman"
-version = "4.4.4"
+version = "4.4.5"
 description = "Monitoring and enumerating Slack for exposed secrets"
 authors = ["PaperMtn <me@papermtn.co.uk>"]
 license = "GPL-3.0"


### PR DESCRIPTION
## [4.4.5] - 2026-04-27
### Changed
- Updated dependabot.yml to created PRs against `develop` branch instead of `maaster`
- Dependabot updates:
  - `requests` updated to `2.33.1`
  - `pygments` updated to `2.20.0`
  - `pytest` updated to `9.0.3`