### PR TITLE
chore: version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.4.5] - 2026-xx-xx
+## [4.4.5] - 2026-04-27
 ### Changed
 - Updated dependabot.yml to created PRs against `develop` branch instead of `maaster`
 - Dependabot updates:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "slack-watchman"
-version = "4.4.4"
+version = "4.4.5"
 description = "Monitoring and enumerating Slack for exposed secrets"
 authors = ["PaperMtn <me@papermtn.co.uk>"]
 license = "GPL-3.0"


### PR DESCRIPTION
## [4.4.5] - 2026-04-27
### Changed
- Updated dependabot.yml to created PRs against `develop` branch instead of `maaster`
- Dependabot updates:
  - `requests` updated to `2.33.1`
  - `pygments` updated to `2.20.0`
  - `pytest` updated to `9.0.3`