### PR TITLE
fix(loggers): drop pointless retry on log_to_stdout exception (#92)

### DIFF
--- a/src/slack_watchman/loggers.py
+++ b/src/slack_watchman/loggers.py
@@ -120,11 +120,13 @@ class StdoutLogger:
                           f'    PUBLIC_PERMALINK: {message.get("file").get("permalink_public")} \n' \
                           f'    -----'
             msg_level = 'RESULT'
+        # Retrying log_to_stdout with the same arguments would fail the
+        # same way every time, so log the failure once and drop the
+        # message rather than spinning on a doomed retry (#92).
         try:
             self.log_to_stdout(message, msg_level)
         except Exception as e:
-            print(e)
-            self.log_to_stdout(message, msg_level)
+            print(f"slack_watchman: failed to log message ({msg_level}): {e}")
 
     # pylint: disable=too-many-statements
     def log_to_stdout(self,


### PR DESCRIPTION
Closes #92.

## What

`StdoutLogger.log` wrapped a single `log_to_stdout` call in a
`try/except` whose handler immediately retried with **identical**
arguments:

```python
try:
    self.log_to_stdout(message, msg_level)
except Exception as e:
    print(e)
    self.log_to_stdout(message, msg_level)   # same args → fails the same way
```

The retry can only fail in the same way as the first call, so the
only effect of a genuine logging failure was a duplicated traceback.

## Fix

Replace the retry with a single contextual error line so the failure
is still visible (this is a security tool — silent log drops would
be worse than the duplicate traceback was) but we don't spin on a
doomed call:

```python
try:
    self.log_to_stdout(message, msg_level)
except Exception as e:
    print(f"slack_watchman: failed to log message ({msg_level}): {e}")
```

The `print(...)` shape is consistent with the existing `print(e)` in
this code path; no new dependencies.

## Verification

- `python -c "import ast; ast.parse(open('src/slack_watchman/loggers.py').read())"` → ok.